### PR TITLE
fix: Avoid using v-app in Vue components not main DOM of an app - MEED-7094 - Meeds-io/MIPs#144

### DIFF
--- a/gamification-crowdin-webapp/src/main/webapp/vue-app/connectorEventExtensions/components/CrowdinEvent.vue
+++ b/gamification-crowdin-webapp/src/main/webapp/vue-app/connectorEventExtensions/components/CrowdinEvent.vue
@@ -17,7 +17,7 @@
  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <v-app>
+  <div>
     <crowdin-connector-event-form
       v-if="isEditing"
       :trigger="trigger"
@@ -26,7 +26,7 @@
       v-else
       :trigger="trigger"
       :properties="properties" />
-  </v-app>
+  </div>
 </template>
 <script>
 export default {

--- a/gamification-crowdin-webapp/src/main/webapp/vue-app/connectorEventExtensions/components/CrowdinEventDisplay.vue
+++ b/gamification-crowdin-webapp/src/main/webapp/vue-app/connectorEventExtensions/components/CrowdinEventDisplay.vue
@@ -17,14 +17,12 @@
  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <v-app>
-    <template>
-      <v-progress-linear
-        v-if="loading"
-        indeterminate
-        height="2"
-        color="primary" />
-    </template>
+  <div>
+    <v-progress-linear
+      v-if="loading"
+      indeterminate
+      height="2"
+      color="primary" />
     <template v-if="items.length && !loading">
       <div class="subtitle-1 font-weight-bold mb-2">
         {{ $t('gamification.event.display.goThere') }}
@@ -35,7 +33,7 @@
         :key="item"
         :item="item" />
     </template>
-  </v-app>
+  </div>
 </template>
 
 <script>

--- a/gamification-crowdin-webapp/src/main/webapp/vue-app/connectorEventExtensions/components/CrowdinEventForm.vue
+++ b/gamification-crowdin-webapp/src/main/webapp/vue-app/connectorEventExtensions/components/CrowdinEventForm.vue
@@ -17,7 +17,7 @@ along with this program; if not, write to the Free Software Foundation,
 Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <v-app>
+  <div>
     <v-card-text class="px-0 dark-grey-color font-weight-bold">
       {{ $t('gamification.crowdin.event.form.project') }}
     </v-card-text>
@@ -139,7 +139,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       :directories="directories"
       :selected-directories="selectedDirectories"
       @apply="selectDirectories" />
-  </v-app>
+  </div>
 </template>
 
 <script>

--- a/gamification-crowdin-webapp/src/main/webapp/vue-app/crowdinAdminConnectorExtension/components/CrowdinAdminConnectorItem.vue
+++ b/gamification-crowdin-webapp/src/main/webapp/vue-app/crowdinAdminConnectorExtension/components/CrowdinAdminConnectorItem.vue
@@ -17,7 +17,7 @@
  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <v-app>
+  <div>
     <template v-if="!displayHookDetail">
       <div class="px-4 py-2 py-sm-5 d-flex align-center">
         <v-tooltip :disabled="$root.isMobile" bottom>
@@ -131,7 +131,7 @@
       :ok-label="$t('confirm.yes')"
       :cancel-label="$t('confirm.no')"
       @ok="deleteSettings" />
-  </v-app>
+  </div>
 </template>
 
 <script>


### PR DESCRIPTION
Prior to this change, the v-app was used in Vue components injected via extensionRegistry. This change will change it to simply use a simple div.