### PR TITLE
fix: Update default charset and collation for mysql - EXO-75202

### DIFF
--- a/gamification-crowdin-services/src/main/resources/db/changelog/crowdin-connector.db.changelog-1.0.0.xml
+++ b/gamification-crowdin-services/src/main/resources/db/changelog/crowdin-connector.db.changelog-1.0.0.xml
@@ -30,6 +30,7 @@
 
     
     <changeSet author="meeds-crowdin-connector" id="1.0.0-1">
+        <validCheckSum>9:4af9fbb3134a8c97e5c8b637fdba0f48</validCheckSum>
         <createTable tableName="CROWDIN_WEBHOOKS">
           <column name="ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
             <constraints nullable="false" primaryKey="true" primaryKeyName="PK_CROWDIN_WEBHOOKS"/>
@@ -40,10 +41,10 @@
           <column name="PROJECT_ID" type="BIGINT">
             <constraints nullable="false"/>
           </column>
-          <column name="PROJECT_NAME" type="NVARCHAR(250)">
+          <column name="PROJECT_NAME" type="VARCHAR(250)">
             <constraints nullable="false"/>
           </column>
-          <column name="TRIGGERS" type="NVARCHAR(2000)">
+          <column name="TRIGGERS" type="VARCHAR(2000)">
             <constraints nullable="false"/>
           </column>
           <column name="ENABLED" type="BOOLEAN">
@@ -61,10 +62,10 @@
           <column name="REFRESH_DATE" type="DATE">
             <constraints nullable="false"/>
           </column>
-          <column name="SECRET" type="NVARCHAR(250)">
+          <column name="SECRET" type="VARCHAR(250)">
             <constraints nullable="false"/>
           </column>
-          <column name="TOKEN" type="NVARCHAR(250)">
+          <column name="TOKEN" type="VARCHAR(250)">
             <constraints nullable="false"/>
           </column>
         </createTable>


### PR DESCRIPTION
fix: Update default charset and collation for mysql - EXO-75202

With mysql 8.4, the default charset and collation are updated from UTF to UTF8MB4. In addition NVARCHAR is now deprecated and replaced by VARCHAR. 
This commit adapt liquibase changes in order to apply this change.

Resolves Meeds-io/meeds#2564