### PR TITLE
fix: Crowdin proofreader events are not well triggered - Meeds-io/meeds#2655

### DIFF
--- a/gamification-crowdin-services/src/main/java/io/meeds/crowdin/gamification/model/RemoteApproval.java
+++ b/gamification-crowdin-services/src/main/java/io/meeds/crowdin/gamification/model/RemoteApproval.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2024 Meeds Lab contact@meedslab.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.crowdin.gamification.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class RemoteApproval implements Cloneable {
+
+  private long                 id;
+
+  private String               userName;
+
+  private String               translationId;
+
+  private String               stringId;
+
+  private String               languageId;
+
+
+}

--- a/gamification-crowdin-services/src/main/java/io/meeds/crowdin/gamification/model/RemoteApproval.java
+++ b/gamification-crowdin-services/src/main/java/io/meeds/crowdin/gamification/model/RemoteApproval.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Meeds project (https://meeds.io/).
  *
- * Copyright (C) 2020 - 2024 Meeds Lab contact@meedslab.com
+ * Copyright (C) 2020 - 2025 Meeds Lab contact@meedslab.com
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/gamification-crowdin-services/src/main/java/io/meeds/crowdin/gamification/plugin/SuggestionApprovedTriggerPlugin.java
+++ b/gamification-crowdin-services/src/main/java/io/meeds/crowdin/gamification/plugin/SuggestionApprovedTriggerPlugin.java
@@ -76,7 +76,6 @@ public class SuggestionApprovedTriggerPlugin extends CrowdinTriggerPlugin {
 
 
     // Retrieve who made that approval by calling Crowdin API
-    try {
       String translationId = extractSubItem(payload, TRANSLATION, ID);
       RemoteApproval remoteApproval = webhookService.getApproval(getProjectId(payload), translationId);
 
@@ -95,11 +94,7 @@ public class SuggestionApprovedTriggerPlugin extends CrowdinTriggerPlugin {
 
       }
 
-    } catch (IllegalAccessException | ObjectNotFoundException e) {
-      LOG.error(e);
-    }
-
-    return eventList;
+      return eventList;
   }
 
   @Override

--- a/gamification-crowdin-services/src/main/java/io/meeds/crowdin/gamification/plugin/SuggestionApprovedTriggerPlugin.java
+++ b/gamification-crowdin-services/src/main/java/io/meeds/crowdin/gamification/plugin/SuggestionApprovedTriggerPlugin.java
@@ -78,7 +78,6 @@ public class SuggestionApprovedTriggerPlugin extends CrowdinTriggerPlugin {
     // Retrieve who made that approval by calling Crowdin API
     try {
       String translationId = extractSubItem(payload, TRANSLATION, ID);
-
       RemoteApproval remoteApproval = webhookService.getApproval(getProjectId(payload), translationId);
 
       if (remoteApproval != null) {

--- a/gamification-crowdin-services/src/main/java/io/meeds/crowdin/gamification/plugin/SuggestionApprovedTriggerPlugin.java
+++ b/gamification-crowdin-services/src/main/java/io/meeds/crowdin/gamification/plugin/SuggestionApprovedTriggerPlugin.java
@@ -20,15 +20,10 @@ package io.meeds.crowdin.gamification.plugin;
 
 import io.meeds.crowdin.gamification.model.Event;
 import io.meeds.crowdin.gamification.model.RemoteApproval;
-import io.meeds.crowdin.gamification.rest.builder.WebHookBuilder;
 import io.meeds.crowdin.gamification.services.CrowdinTriggerService;
 import io.meeds.crowdin.gamification.services.WebhookService;
-import io.meeds.gamification.model.RealizationDTO;
 import io.meeds.gamification.service.RealizationService;
 import jakarta.annotation.PostConstruct;
-import org.exoplatform.commons.exception.ObjectNotFoundException;
-import org.exoplatform.services.log.ExoLogger;
-import org.exoplatform.services.log.Log;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -41,8 +36,6 @@ import java.util.Map;
 @Component
 public class SuggestionApprovedTriggerPlugin extends CrowdinTriggerPlugin {
 
-  private static final Log LOG = ExoLogger.getLogger(SuggestionApprovedTriggerPlugin.class);
-
   @Autowired
   private CrowdinTriggerService crowdinTriggerService;
 
@@ -50,7 +43,7 @@ public class SuggestionApprovedTriggerPlugin extends CrowdinTriggerPlugin {
   private RealizationService    realizationService;
 
   @Autowired
-  private WebhookService webhookService;
+  private WebhookService        webhookService;
 
   @PostConstruct
   public void init() {
@@ -63,38 +56,36 @@ public class SuggestionApprovedTriggerPlugin extends CrowdinTriggerPlugin {
 
     List<Event> eventList = new ArrayList<>();
     eventList.add(new Event(SUGGESTION_APPROVED_EVENT_NAME,
-            extractSubItem(payload, TRANSLATION, USER, USERNAME),
-            extractSubItem(payload, TRANSLATION, USER, USERNAME),
-            objectId,
-            TRANSLATION,
-            getProjectId(payload),
-            extractSubItem(payload, TRANSLATION, TARGET_LANGUAGE, ID),
-            extractSubItem(payload, TRANSLATION, PROVIDER) == null,
-            extractSubItem(payload, TRANSLATION, STRING, FILE, DIRECTORY_ID),
-            trigger.equals(SUGGESTION_DISAPPROVED_TRIGGER),
-            countWords(extractSubItem(payload, TRANSLATION, STRING, TEXT))));
-
+                            extractSubItem(payload, TRANSLATION, USER, USERNAME),
+                            extractSubItem(payload, TRANSLATION, USER, USERNAME),
+                            objectId,
+                            TRANSLATION,
+                            getProjectId(payload),
+                            extractSubItem(payload, TRANSLATION, TARGET_LANGUAGE, ID),
+                            extractSubItem(payload, TRANSLATION, PROVIDER) == null,
+                            extractSubItem(payload, TRANSLATION, STRING, FILE, DIRECTORY_ID),
+                            trigger.equals(SUGGESTION_DISAPPROVED_TRIGGER),
+                            countWords(extractSubItem(payload, TRANSLATION, STRING, TEXT))));
 
     // Retrieve who made that approval by calling Crowdin API
-      String translationId = extractSubItem(payload, TRANSLATION, ID);
-      RemoteApproval remoteApproval = webhookService.getApproval(getProjectId(payload), translationId);
+    String translationId = extractSubItem(payload, TRANSLATION, ID);
+    RemoteApproval remoteApproval = webhookService.getApproval(getProjectId(payload), translationId);
 
-      if (remoteApproval != null) {
-        eventList.add(new Event(APPROVE_SUGGESTION_EVENT_NAME,
-                remoteApproval.getUserName(),
-                remoteApproval.getUserName(),
-                objectId,
-                TRANSLATION,
-                getProjectId(payload),
-                extractSubItem(payload, TRANSLATION, TARGET_LANGUAGE, ID),
-                extractSubItem(payload, TRANSLATION, PROVIDER) == null,
-                extractSubItem(payload, TRANSLATION, STRING, FILE, DIRECTORY_ID),
-                trigger.equals(SUGGESTION_DISAPPROVED_TRIGGER),
-                countWords(extractSubItem(payload, TRANSLATION, STRING, TEXT))));
+    if (remoteApproval != null) {
+      eventList.add(new Event(APPROVE_SUGGESTION_EVENT_NAME,
+                              remoteApproval.getUserName(),
+                              remoteApproval.getUserName(),
+                              objectId,
+                              TRANSLATION,
+                              getProjectId(payload),
+                              extractSubItem(payload, TRANSLATION, TARGET_LANGUAGE, ID),
+                              extractSubItem(payload, TRANSLATION, PROVIDER) == null,
+                              extractSubItem(payload, TRANSLATION, STRING, FILE, DIRECTORY_ID),
+                              trigger.equals(SUGGESTION_DISAPPROVED_TRIGGER),
+                              countWords(extractSubItem(payload, TRANSLATION, STRING, TEXT))));
 
-      }
-
-      return eventList;
+    }
+    return eventList;
   }
 
   @Override

--- a/gamification-crowdin-services/src/main/java/io/meeds/crowdin/gamification/services/WebhookService.java
+++ b/gamification-crowdin-services/src/main/java/io/meeds/crowdin/gamification/services/WebhookService.java
@@ -57,16 +57,12 @@ public class WebhookService {
     return crowdinConsumerStorage.getProjects(accessToken);
   }
 
-  public RemoteApproval getApproval(String projectId, String translationId)
-          throws IllegalAccessException, ObjectNotFoundException {
-
+  public RemoteApproval getApproval(String projectId, String translationId) {
     WebHook webHook = webHookStorage.getWebhookByProjectId(Long.parseLong(projectId));
-
-    if (webHook == null) {
-      throw new ObjectNotFoundException("Webhook with project id '" + projectId + "' doesn't exist");
+    if (webHook != null) {
+      return crowdinConsumerStorage.getApproval(webHook.getToken(), projectId, translationId);
     }
-
-    return crowdinConsumerStorage.getApproval(webHook.getToken(), projectId, translationId);
+    return null;
   }
 
   public WebHook createWebhook(long projectId,

--- a/gamification-crowdin-services/src/main/java/io/meeds/crowdin/gamification/services/WebhookService.java
+++ b/gamification-crowdin-services/src/main/java/io/meeds/crowdin/gamification/services/WebhookService.java
@@ -18,6 +18,7 @@
  */
 package io.meeds.crowdin.gamification.services;
 
+import io.meeds.crowdin.gamification.model.RemoteApproval;
 import io.meeds.crowdin.gamification.model.RemoteDirectory;
 import io.meeds.crowdin.gamification.model.RemoteProject;
 import io.meeds.crowdin.gamification.model.WebHook;
@@ -56,10 +57,22 @@ public class WebhookService {
     return crowdinConsumerStorage.getProjects(accessToken);
   }
 
+  public RemoteApproval getApproval(String projectId, String translationId)
+          throws IllegalAccessException, ObjectNotFoundException {
+
+    WebHook webHook = webHookStorage.getWebhookByProjectId(Long.parseLong(projectId));
+
+    if (webHook == null) {
+      throw new ObjectNotFoundException("Webhook with project id '" + projectId + "' doesn't exist");
+    }
+
+    return crowdinConsumerStorage.getApproval(webHook.getToken(), projectId, translationId);
+  }
+
   public WebHook createWebhook(long projectId,
-                            String projectName,
-                            String accessToken,
-                            String currentUser) throws ObjectAlreadyExistsException, IllegalAccessException {
+                               String projectName,
+                               String accessToken,
+                               String currentUser) throws ObjectAlreadyExistsException, IllegalAccessException {
     if (!Utils.isRewardingManager(currentUser)) {
       throw new IllegalAccessException("The user is not authorized to create Crowdin hook");
     }
@@ -80,7 +93,7 @@ public class WebhookService {
   }
 
   public void updateWebHookAccessToken(long webHookId, String accessToken, String currentUser) throws IllegalAccessException,
-                                                                                               ObjectNotFoundException {
+          ObjectNotFoundException {
     if (!Utils.isRewardingManager(currentUser)) {
       throw new IllegalAccessException(AUTHORIZED_TO_ACCESS_CROWDIN_HOOKS);
     }

--- a/gamification-crowdin-services/src/main/java/io/meeds/crowdin/gamification/storage/CrowdinConsumerStorage.java
+++ b/gamification-crowdin-services/src/main/java/io/meeds/crowdin/gamification/storage/CrowdinConsumerStorage.java
@@ -378,7 +378,7 @@ public class CrowdinConsumerStorage {
   }
 
   public RemoteApproval getApproval(String accessToken, String projectId, String translationId)
-          throws IllegalAccessException {
+             {
 
     try {
 
@@ -401,10 +401,9 @@ public class CrowdinConsumerStorage {
 
       return remoteApproval;
 
-    } catch (IllegalArgumentException e) {
-      throw new IllegalArgumentException(e);
     } catch (CrowdinConnectionException e) {
-      throw new IllegalAccessException(TOKEN_EXPIRED_OR_INVALID);
+      LOG.warn("Unable to retrieve approval for crowdin translation with id {}.", translationId, e);
+      return null;
     }
   }
 

--- a/gamification-crowdin-services/src/main/java/io/meeds/crowdin/gamification/storage/CrowdinConsumerStorage.java
+++ b/gamification-crowdin-services/src/main/java/io/meeds/crowdin/gamification/storage/CrowdinConsumerStorage.java
@@ -377,11 +377,8 @@ public class CrowdinConsumerStorage {
     }
   }
 
-  public RemoteApproval getApproval(String accessToken, String projectId, String translationId)
-             {
-
+  public RemoteApproval getApproval(String accessToken, String projectId, String translationId) {
     try {
-
       URI uri = URI.create(CROWDIN_API_URL + PROJECTS + projectId + APPROVALS + translationId);
 
       String response = processGet(uri, accessToken);
@@ -400,7 +397,6 @@ public class CrowdinConsumerStorage {
       remoteApproval.setLanguageId(jsonObject.getString("languageId"));
 
       return remoteApproval;
-
     } catch (CrowdinConnectionException e) {
       LOG.warn("Unable to retrieve approval for crowdin translation with id {}.", translationId, e);
       return null;

--- a/gamification-crowdin-services/src/main/java/io/meeds/crowdin/gamification/utils/Utils.java
+++ b/gamification-crowdin-services/src/main/java/io/meeds/crowdin/gamification/utils/Utils.java
@@ -18,7 +18,7 @@ public class Utils {
   public static final String   CONNECTOR_NAME                     = "crowdin";
 
   public static final String[] CROWDIN_EVENTS                     = new String[] { "stringComment.created",
-      "stringComment.deleted", "suggestion.added", "suggestion.deleted", "suggestion.approved", "suggestion.disapproved" };
+          "stringComment.deleted", "suggestion.added", "suggestion.deleted", "suggestion.approved", "suggestion.disapproved" };
 
   public static final String   PROJECT_ID                         = "projectId";
 
@@ -33,6 +33,8 @@ public class Utils {
   public static final String   PROJECTS                           = "/projects/";
 
   public static final String   WEBHOOKS                           = "/webhooks/";
+
+  public static final String   APPROVALS                           = "/approvals/";
 
   public static final String   AUTHORIZED_TO_ACCESS_CROWDIN_HOOKS = "The user is not authorized to access crowdin Hooks";
 
@@ -57,7 +59,7 @@ public class Utils {
   public static final String   LANGUAGE_ID                        = "languageId";
 
   public static final String   MUST_BE_HUMAN                      = "mustBeHuman";
-  
+
   public static final String   TOTAL_TARGET_ITEM                  = "totalTargetItem";
 
   public static final String   STRING                             = "string";
@@ -65,7 +67,7 @@ public class Utils {
   public static final String   TARGET_LANGUAGE                    = "targetLanguage";
 
   public static final String   PROJECT                            = "project";
-  
+
   public static final String   TEXT                               = "text";
 
   public static final String   ID                                 = "id";
@@ -180,7 +182,7 @@ public class Utils {
     String sourceLanguageId = extractSubItem(payload, payloadObjectName, STRING, PROJECT, SOURCE_LANGUAGE_ID);
     String targetLanguageId = extractSubItem(payload, payloadObjectName, TARGET_LANGUAGE, ID);
     return "{\"id\":" + id + ",\"stringUrl\":\"https://crowdin.com/editor/" + projectSlug + "/" + fileId + "/" + sourceLanguageId
-        + "-" + targetLanguageId + "?view=comfortable#" + stringId + "\"}";
+            + "-" + targetLanguageId + "?view=comfortable#" + stringId + "\"}";
   }
 
   public static int countWords(String text) {

--- a/gamification-crowdin-services/src/main/java/io/meeds/crowdin/gamification/utils/Utils.java
+++ b/gamification-crowdin-services/src/main/java/io/meeds/crowdin/gamification/utils/Utils.java
@@ -34,7 +34,7 @@ public class Utils {
 
   public static final String   WEBHOOKS                           = "/webhooks/";
 
-  public static final String   APPROVALS                           = "/approvals/";
+  public static final String   APPROVALS                          = "/approvals/";
 
   public static final String   AUTHORIZED_TO_ACCESS_CROWDIN_HOOKS = "The user is not authorized to access crowdin Hooks";
 


### PR DESCRIPTION
The suggestion.approved webhook from Crowdin no longer provides the proofreader information in the payload. Instead, it only includes the translator details.

Now to get proofreader details, we call the Crowdin API after receiving the webhook.

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
