### PR TITLE
fix: Crowdin proofreader events are not well triggered - Meeds-io/meeds#2655

### DIFF
--- a/gamification-crowdin-services/src/main/java/io/meeds/crowdin/gamification/storage/CrowdinConsumerStorage.java
+++ b/gamification-crowdin-services/src/main/java/io/meeds/crowdin/gamification/storage/CrowdinConsumerStorage.java
@@ -377,12 +377,11 @@ public class CrowdinConsumerStorage {
     }
   }
 
-  public RemoteApproval getApproval(
-          String accessToken, String projectId, String translationId) {
+  public RemoteApproval getApproval(String accessToken, String projectId,String translationId) {
 
     try {
 
-      URI uri = URI.create(CROWDIN_API_URL + PROJECTS + projectId + APPROVALS + "?translationId="+ translationId);
+      URI uri = URI.create(CROWDIN_API_URL + PROJECTS + projectId + APPROVALS + "?translationId=" + translationId);
 
       String response = processGet(uri, accessToken);
       JSONArray jsonArray = new JSONObject(response).getJSONArray("data");


### PR DESCRIPTION
The Get Approval API used Translator ID by mistake assuming it was the same as approval ID.

Now to get proofreader details, we call the Crowdin List Translation Approvals API after receiving the webhook.

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
