### PR TITLE
fix: Crowdin proofreader cancelling event is not well triggered - Meeds-io/meeds#2655

### DIFF
--- a/gamification-crowdin-services/src/main/java/io/meeds/crowdin/gamification/plugin/SuggestionApprovedTriggerPlugin.java
+++ b/gamification-crowdin-services/src/main/java/io/meeds/crowdin/gamification/plugin/SuggestionApprovedTriggerPlugin.java
@@ -83,7 +83,7 @@ public class SuggestionApprovedTriggerPlugin extends CrowdinTriggerPlugin {
                 remoteApproval.getUserName(),
                 remoteApproval.getUserName(),
                 objectId,
-                TRANSLATION,
+                APPROVAL,
                 getProjectId(payload),
                 extractSubItem(payload, TRANSLATION, TARGET_LANGUAGE, ID),
                 extractSubItem(payload, TRANSLATION, PROVIDER) == null,
@@ -97,7 +97,7 @@ public class SuggestionApprovedTriggerPlugin extends CrowdinTriggerPlugin {
       // Retrieve who made that approval from the database
 
       List<RealizationDTO> realizations = realizationService.
-              findRealizationsByObjectIdAndObjectType(objectId, TRANSLATION);
+              findRealizationsByObjectIdAndObjectType(objectId, APPROVAL);
 
       if ( ! realizations.isEmpty()) {
         String approvalUsername = realizations.get(0).getEarnerId();
@@ -113,8 +113,6 @@ public class SuggestionApprovedTriggerPlugin extends CrowdinTriggerPlugin {
                 extractSubItem(payload, TRANSLATION, STRING, FILE, DIRECTORY_ID),
                 true,
                 countWords(extractSubItem(payload, TRANSLATION, STRING, TEXT))));
-      } else {
-        LOG.warn("No realization found while cancelling translation with id: " + objectId);
       }
 
     }

--- a/gamification-crowdin-services/src/main/java/io/meeds/crowdin/gamification/utils/Utils.java
+++ b/gamification-crowdin-services/src/main/java/io/meeds/crowdin/gamification/utils/Utils.java
@@ -92,6 +92,8 @@ public class Utils {
 
   public static final String   TRANSLATION                        = "translation";
 
+  public static final String   APPROVAL                           = "approval";
+
   public static final String   SUGGESTION_ADDED_TRIGGER           = "suggestion.added";
 
   public static final String   SUGGESTION_DELETED_TRIGGER         = "suggestion.deleted";


### PR DESCRIPTION
Currently while cancelling points are removed for the translator, but not for the approver but it should.
This pull request intends to make sure that the points are removed for the translator as well by getting 
the previous approval user from the database.

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
